### PR TITLE
feat: use coreutils for ls --color=auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ dotfiles for my personal use.
 ### Step 2: Checkout the relevant branch
 
 ## Setup
+### Install dependencies
+TODO: Install brew
+```
+
+```
+```
+$ brew install coreutils
+```
+
 ```
 $ cd ~/.config/dotfiles
 $ git pull

--- a/home/.zlogout
+++ b/home/.zlogout
@@ -1,0 +1,2 @@
+# in ~/.zshenv, executed `unsetopt GLOBAL_RCS` and ignored /etc/zlogout
+[ -r /etc/zlogout ] && . /etc/zlogout

--- a/home/.zshenv
+++ b/home/.zshenv
@@ -1,0 +1,22 @@
+# -U: keep only the first occurrence of each duplicated value
+# ref. http://zsh.sourceforge.net/Doc/Release/Shell-Builtin-Commands.html#index-typeset
+typeset -U path manpath
+
+# ignore /etc/zprofile, /etc/zshrc, /etc/zlogin, and /etc/zlogout
+# ref. http://zsh.sourceforge.net/Doc/Release/Files.html
+unsetopt GLOBAL_RCS
+# copied from /etc/zprofile
+# system-wide environment settings for zsh(1)
+if [ -x /usr/libexec/path_helper ]; then
+  eval `/usr/libexec/path_helper -s`
+fi
+
+path=(
+  /usr/local/opt/coreutils/libexec/gnubin(N-/) # coreutils
+  ${path}
+)
+
+manpath=(
+  /usr/local/opt/coreutils/libexec/gnuman(N-/) # coreutils
+  ${manpath}
+)

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -1,3 +1,8 @@
+# in ~/.zshenv, executed `unsetopt GLOBAL_RCS`
+# and ignored /etc/zshrc, /etc/zlogin
+[ -r /etc/zshrc ] && . /etc/zshrc
+[ -r /etc/zlogin ] && . /etc/zlogin
+
 fpath+=(~/.local/share/zsh/site-functions)
 autoload -Uz add-zsh-hook
 
@@ -7,7 +12,8 @@ autoload -Uz add-zsh-hook
 alias grep='grep --color=auto'
 alias fgrep='fgrep --color=auto'
 alias egrep='egrep --color=auto'
-alias ls='ls -lh'
+alias ls='ls -F --color=auto'
+alias ll='ls -lh'
 alias la='ls -lAh'
 
 autoload -Uz promptinit && promptinit

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,7 @@ source "$DOTFILE_DIR/scripts/setup"
 
 @install Install Shell Config
   - .zshrc
+  - .zshenv
   - .local/share/zsh/site-functions
 
 @install Install Vim  Config


### PR DESCRIPTION
# 概要
`ls`のオプションで`--color=auto`を利用するため、`coreutils`の`ls`を使うようにする
`~/.zshenv`で`coreutils`のlsを使うための`path`設定をしたが、デフォルトの状態では`~/.zshenv`の実行後に`/etc/zprofile`が実行され、`path`が上書きされる
上記を阻止するため、`unsetopt GLOBAL_RCS`を設定し、`/etc/zprofile`の内容を手動で実行するように修正した

設定後の挙動
```
% which -a ls
ls: aliased to ls -F --color=auto
/usr/local/opt/coreutils/libexec/gnubin/ls
/bin/ls
```