### PR TITLE
chore: set re=0 in typescript

### DIFF
--- a/home/.vim/vimrc
+++ b/home/.vim/vimrc
@@ -74,4 +74,4 @@ nnoremap <silent> <Leader>tf :NERDTreeToggle<CR>
 "  Auto Commands  "
 """""""""""""""""""
 autocmd VimEnter * :NERDTreeToggle | wincmd p
-autocmd Filetype typescript setl re=2 " vim hangs when ts file is opend if re=1 (default)
+autocmd Filetype typescript setl re=0 " vim hangs when ts file is opend if re=1 (default)


### PR DESCRIPTION
`re=2`だと` 'redrawtime' exceeded, syntax highlighting disabled`となり`vim`がhangする