### PR TITLE
feat: highlight trailing spaces

### DIFF
--- a/home/.vim/vimrc
+++ b/home/.vim/vimrc
@@ -75,3 +75,8 @@ nnoremap <silent> <Leader>tf :NERDTreeToggle<CR>
 """""""""""""""""""
 autocmd VimEnter * :NERDTreeToggle | wincmd p
 autocmd Filetype typescript setl re=0 " vim hangs when ts file is opend if re=1 (default)
+augroup HighlightTrailingSpaces
+  autocmd!
+  autocmd VimEnter,WinEnter,ColorScheme * highlight TrailingSpaces term=underline guibg=Red ctermbg=Red
+  autocmd VimEnter,WinEnter,ColorScheme * match TrailingSpaces /\s\+$/
+augroup END


### PR DESCRIPTION
- augroup
  https://vimdoc.sourceforge.net/htmldoc/autocmd.html
  ```
  Autocommands can be put together in a group.  This is useful for removing or
  executing a group of autocommands.  For example, all the autocommands for
  syntax highlighting are put in the "highlight" group, to be able to execute
  ":doautoall highlight BufRead" when the GUI starts.
  
							  *:aug* *:augroup*
  :aug[roup] {name}		Define the autocmd group name for the
				  following ":autocmd" commands.  The name "end"
				  or "END" selects the default group.
  ```
- autocmd!
  https://vimdoc.sourceforge.net/htmldoc/autocmd.html
  ```
  When your .vimrc file is sourced twice, the autocommands will appear twice.
  To avoid this, put this command in your .vimrc file, before defining
  autocommands:
  
	  :autocmd!	" Remove ALL autocommands for the current group.
  
  If you don't want to remove all autocommands, you can instead use a variable
  to ensure that Vim includes the autocommands only once:
  ```
- autocmd
  https://vimdoc.sourceforge.net/htmldoc/autocmd.html
  ```
  :au[tocmd] [group] {event} {pat} [nested] {cmd}
			  Add {cmd} to the list of commands that Vim will
			  execute automatically on {event} for a file matching
			  {pat} |autocmd-patterns|.
			  Vim always adds the {cmd} after existing autocommands,
			  so that the autocommands execute in the order in which
			  they were given.  See |autocmd-nested| for [nested].
  ```
  - event
    - VimEnter
      ```
      VimEnter			After doing all the startup stuff, including
				      loading .vimrc files, executing the "-c cmd"
				      arguments, creating all windows and loading
				      the buffers in them.
      ```
    - WinEnter
      ```
      WinEnter			After entering another window.  Not done for
				      the first window, when Vim has just started.
				      Useful for setting the window height.
				      If the window is for another buffer, Vim
				      executes the BufEnter autocommands after the
				      WinEnter autocommands.
				      Note: When using ":split fname" the WinEnter
				      event is triggered after the split but before
				      the file "fname" is loaded.
      ```
      これがないと、vim編集画面を分割したときにhighlight設定が反映されない。
    - ColorSchema
      ```
      ColorScheme			After loading a color scheme. |:colorscheme|
      ```
  - cmd
    - highlight
       https://vimdoc.sourceforge.net/htmldoc/syntax.html#:highlight
       ```
      :hi[ghlight] [default] {group-name} {key}={arg} ..
			      Add a highlight group, or change the highlighting for
			      an existing group.
      ```
      - args
         https://vimdoc.sourceforge.net/htmldoc/syntax.html#highlight-args
         - term: `highlight arguments for normal terminals`
         - guibg: `highlight arguments for the GUI`
         - ctermbg: `highlight arguments for color terminals`
         