### PR TITLE
feat: unsetopt nomatch in zsh

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -100,6 +100,8 @@ autoload -Uz promptinit && promptinit
 prompt concise
 unsetopt prompt_cr
 
+unsetopt nomatch # Do not raise error when glob can not be expanded
+
 ###############
 #  loads nvm  #
 ###############


### PR DESCRIPTION
zshでglob展開時にファイルが存在しなくてもエラーにならないように設定。