### PR TITLE
feat: managing packages by nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ git worktree add ~/.dotfiles local
 pushd ~/.dotfiles
 ./setup.sh
 ```
+
+### Bootstrap Nix home-manager
+```
+nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,249 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim-nightly-overlay",
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730903510,
+        "narHash": "sha256-mnynlrPeiW0nUQ8KGZHb3WyxAxA3Ye/BH8gMjdoKP6E=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "b89ac4d66d618b915b1f0a408e2775fe3821d141",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731832479,
+        "narHash": "sha256-icDDuYwJ0avTMZTxe1qyU/Baht5JOqw4pb5mWpR+hT0=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "5056a1cf0ce7c2a08ab50713b6c4af77975f6111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "neovim-nightly-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "hercules-ci-effects": "hercules-ci-effects",
+        "neovim-src": "neovim-src",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1731764158,
+        "narHash": "sha256-RJ9xa3O8LCyw90BT2HooAmBiXns20+2ocLd1GDO54qg=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "973f6526dd30053a7ef98017272207af00bd615b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731710082,
+        "narHash": "sha256-TUrqqpotTHgRpsocfXrT0QRJwJCT2xB7rHS0k1U1E0w=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "6e4df18b457e9743c34068fd6e0a89fd04d3526c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1731763621,
+        "narHash": "sha256-ddcX4lQL0X05AYkrkV2LMFgGdRvgap7Ho8kgon3iWZk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c69a9bffbecde46b4b939465422ddc59493d3e4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "neovim-nightly-overlay": "neovim-nightly-overlay",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Nix configuration for dotfiles";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    home-manager,
+    ...
+  } @ inputs: let
+    system = "x86_64-darwin";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    apps.${system}.update = {
+      type = "app";
+      program = toString (pkgs.writeShellScript "update-script" ''
+        set -e
+        echo "Updating flake..."
+        nix flake update
+        echo "Updating home-manager..."
+        nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
+        echo "Update complete!"
+      '');
+    };
+
+    homeConfigurations = {
+      myHomeConfig = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+
+        extraSpecialArgs = {
+          inherit inputs;
+        };
+
+        modules = [ ./nix/home.nix ];
+      };
+    };
+  };
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,0 +1,33 @@
+{
+  inputs,
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  username = "nomu";
+in {
+  nixpkgs = {
+    overlays = [
+      inputs.neovim-nightly-overlay.overlays.default
+    ];
+  };
+
+  home = {
+    inherit username;
+    homeDirectory = "/Users/${username}";
+
+    packages = with pkgs; [
+      curl
+      fzf
+      git
+      neovim
+      volta
+    ];
+
+    stateVersion = "24.05";
+  };
+
+  # Let Home Manager install and manage itself.
+  programs.home-manager.enable = true;
+}


### PR DESCRIPTION
- Nixは以下でインストール
  <details>
  <summary>log</summary>
  
  ```
  % which nix
  nix not found
  
  % curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
    sh -s -- install
  info: downloading installer (https://install.determinate.systems/nix/tag/v0.27.1/nix-installer-x86_64-darwin)
   INFO nix-installer v0.27.1
  `nix-installer` needs to run as `root`, attempting to escalate now via `sudo`...
  Password:
   INFO nix-installer v0.27.1
  Nix install plan (v0.27.1)
  Planner: macos (with default settings)
  
  Planned actions:
  * Create an APFS volume `Nix Store` for Nix on `disk1` and add it to `/etc/fstab` mounting on `/nix`
  * Extract the bundled Nix (originally from /nix/store/2mkysa4nd6sr8wj0lfk5cp5fqmb93hnc-nix-binary-tarball-2.24.10/nix-2.24.10-x86_64-darwin.tar.xz)
  * Create a directory tree in `/nix`
  * Move the downloaded Nix into `/nix`
  * Create build users (UID 351-382) and group (GID 350)
  * Configure Time Machine exclusions
  * Setup the default Nix profile
  * Place the Nix configuration in `/etc/nix/nix.conf`
  * Configure the shell profiles
  * Configuring zsh to support using Nix in non-interactive shells
  * Create a `launchctl` plist to put Nix into your PATH
  * Configure upstream Nix daemon service
  * Remove directory `/nix/temp-install-dir`
  
  
  Proceed? ([Y]es/[n]o/[e]xplain): Y
   INFO Step: Create an APFS volume `Nix Store` for Nix on `disk1` and add it to `/etc/fstab` mounting on `/nix`
   INFO Step: Provision Nix
   INFO Step: Create build users (UID 351-382) and group (GID 350)
   INFO Step: Configure Time Machine exclusions
   INFO Step: Configure Nix
   INFO Step: Configuring zsh to support using Nix in non-interactive shells
   INFO Step: Create a `launchctl` plist to put Nix into your PATH
   INFO Step: Configure upstream Nix daemon service
   INFO Step: Remove directory `/nix/temp-install-dir`
  Nix was installed successfully!
  To get started using Nix, open a new shell or run `. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`
  
  % nix --version
  nix (Nix) 2.24.10
  ```
  </details>

- `overlays`を使い、`nixpkgs`を拡張し`neovim`をインストール
https://nixos.wiki/wiki/Overlays#In_a_Nix_flake
https://github.com/nix-community/neovim-nightly-overlay
- `home-manager.inputs.nixpkgs.follows = "nixpkgs";`とすることで、`nixpkgs`と`home-manager`のバージョンを合わせる
https://nixos.wiki/wiki/Overlays#In_a_Nix_flake
しかし、バージョン不一致のエラーが発生する
  ```
  trace: warning: You are using
  
    Home Manager version 24.11 and
    Nixpkgs version 25.05.
  
  Using mismatched versions is likely to cause errors and unexpected
  behavior. It is therefore highly recommended to use a release of Home
  Manager that corresponds with your chosen release of Nixpkgs.
  
  If you insist then you can disable this warning by adding
  
    home.enableNixpkgsReleaseCheck = false;
  
  to your configuration.
  ```
  nixpkgs-24.11はまだリリースされていない
  `https://github.com/NixOS/nixpkgs/issues/339153`
- `nix run #.update`で`apps.${system}.update`に指定された処理（更新）を実行する
https://nix.dev/manual/nix/2.17/command-ref/new-cli/nix3-run#apps
  - `homeConfigurations`で定義する
https://github.com/nix-community/home-manager/blob/a9953635d7f34e7358d5189751110f87e3ac17da/docs/home-manager.1#L229
  >        --flake flake-uri[#name]
  >           Build Home Manager configuration from the flake, which must contain the output homeConfigurations.name. If no  name  is
  >           specified it will first try username@hostname and then username.