### PR TITLE
feat: enable nix-direnv

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -4,6 +4,9 @@
 fpath+=(~/.local/share/zsh/site-functions)
 autoload -Uz add-zsh-hook
 
+# https://direnv.net/docs/hook.html#zsh
+(( $+commands[direnv] )) && eval "$(direnv hook zsh)"
+
 # Alias
 alias ..='cd ..'
 alias ...='cd ../../'
@@ -44,7 +47,7 @@ zmodload -i zsh/complist
 
 # The option EXTENDED_GLOB is set locally
 () {
-  # make different syntax for glob qualifiers available, namely ‘(#qx)’ 
+  # make different syntax for glob qualifiers available, namely ‘(#qx)’
   setopt localoptions extended_glob
   autoload -Uz compinit
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -34,6 +34,14 @@ in {
     stateVersion = "24.05";
   };
 
+  programs = {
+    # https://github.com/nix-community/nix-direnv
+    direnv = {
+      enable = true;
+      nix-direnv.enable = true;
+    };
+  };
+
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;
 }


### PR DESCRIPTION
# Overview
- direnvを有効化
https://github.com/nix-community/nix-direnv/tree/master
https://direnv.net/
  - `home.nix`
  https://github.com/nix-community/nix-direnv/tree/master?tab=readme-ov-file#via-home-manager
    - `zsh`なので`enableBashIntegration = true`は不要
  - `.zshrc`
https://direnv.net/docs/hook.html
    - `(( $+commands[direnv] ))`
      - `direnv`コマンドの存在確認
        - `commands`
https://zsh.sourceforge.io/Doc/Release/Zsh-Modules.html#index-commands
          - コマンドパスの配列
             ```
            % echo $commands[ls]
            /Users/***/.nix-profile/bin/ls
            ```
        - `$+`
https://zsh.sourceforge.io/Doc/Release/Expansion.html#:~:text=${+name}
          - 変数が存在するなら1を、存在しないなら0を返す
            ```
            % echo $+commands[ls]
            1
            % echo $+commands[hoge]
            0
            ```
        - `(())`
        https://zsh.sourceforge.io/Doc/Release/Arithmetic-Evaluation.html
          > The return status is 0 if the arithmetic value of the expression is non-zero, 1 if it is zero, and 2 if an error occurred.
          - `direnv`が存在 → `$+commands[direnv]`が1 → `(( 1 ))`が`0`(success)

# Example
```
% cat .envrc
use flake
```
```
% cat flake.nix
{
  description = "A very basic flake";

  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
  };

  outputs = { self, nixpkgs }:
  let
    pkgs = nixpkgs.legacyPackages.x86_64-darwin;
  in
  {
    devShells.x86_64-darwin.default = pkgs.mkShellNoCC {
      packages = with pkgs; [
        python312
      ];
      FOO = "BAR";
    };
  };
}
```
```
% eval "$(direnv hook zsh)"
direnv: loading ~/Workspace/demo-direnv/.envrc
direnv: using flake
[44.5 MiB DL] unpacking 'github:nixos/nixpkgs/22c3f2cf41a0e70184334a958e6b124fb0ce3e01' into the Git cachedirenv: ([/Users/nomu/.nix-profile/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
warning: creating lock file '/Users/nomu/Workspace/demo-direnv/flake.lock':
• Added input 'nixpkgs':
    'github:nixos/nixpkgs/22c3f2cf41a0e70184334a958e6b124fb0ce3e01?narHash=sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY%3D' (2024-12-07)
direnv: nix-direnv: Renewed cache
direnv: export +CONFIG_SHELL +DETERMINISTIC_BUILD +DEVELOPER_DIR +FOO +HOST_PATH +IN_NIX_SHELL +MACOSX_DEPLOYMENT_TARGET +NIX_APPLE_SDK_VERSION +NIX_BUILD_CORES +NIX_CFLAGS_COMPILE +NIX_DONT_SET_RPATH +NIX_DONT_SET_RPATH_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_IGNORE_LD_THROUGH_GCC +NIX_LDFLAGS +NIX_NO_SELF_RPATH +NIX_STORE +PATH_LOCALE +PYTHONHASHSEED +PYTHONNOUSERSITE +PYTHONPATH +SDKROOT +SOURCE_DATE_EPOCH +__darwinAllowLocalNetworking +__impureHostDeps +__propagatedImpureHostDeps +__propagatedSandboxProfile +__sandboxProfile +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~PATH ~XDG_DATA_DIRS
```
```
% python --version
Python 3.12.7

% echo $FOO
BAR

% ..
direnv: unloading

% echo $FOO

% cd demo-direnv
direnv: loading ~/Workspace/demo-direnv/.envrc
direnv: using flake
direnv: nix-direnv: Using cached dev shell
	direnv: export +CONFIG_SHELL +DETERMINISTIC_BUILD +DEVELOPER_DIR +FOO +HOST_PATH +IN_NIX_SHELL +MACOSX_DEPLOYMENT_TARGET +NIX_APPLE_SDK_VERSION +NIX_BUILD_CORES +NIX_CFLAGS_COMPILE +NIX_DONT_SET_RPATH +NIX_DONT_SET_RPATH_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_IGNORE_LD_THROUGH_GCC +NIX_LDFLAGS +NIX_NO_SELF_RPATH +NIX_STORE +PATH_LOCALE +PYTHONHASHSEED +PYTHONNOUSERSITE +PYTHONPATH +SDKROOT +SOURCE_DATE_EPOCH +__darwinAllowLocalNetworking +__impureHostDeps +__propagatedImpureHostDeps +__propagatedSandboxProfile +__sandboxProfile +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~PATH ~XDG_DATA_DIRS
```