### PR TITLE
add: nvim init.lua

### DIFF
--- a/conf/dotfile_list
+++ b/conf/dotfile_list
@@ -1,5 +1,6 @@
 .bashrc
 .config/git/config
+.config/nvim/init.lua
 .local/share/zsh/site-functions
 .nvm
 .tmux.conf

--- a/home/.config/nvim/init.lua
+++ b/home/.config/nvim/init.lua
@@ -1,0 +1,112 @@
+local augroup = vim.api.nvim_create_augroup("vimrc", { clear = true })
+
+-- {{{ General
+
+-- keep backup file after overwriting a file
+vim.opt.backup = true
+-- default backupdir is .,~/.local/state/nvim/backup//
+vim.opt.backupdir:remove(".")
+-- save undo information in a file
+vim.opt.undofile = true
+-- ignore case in search patterns
+vim.opt.ignorecase = true
+-- no ignore case when pattern has uppercase
+vim.opt.smartcase = true
+
+vim.cmd("silent! packadd! cfilter")
+
+-- }}}
+-- {{{ Editing
+
+-- Use the appropriate number of spaces to insert a <Tab>
+vim.opt.expandtab = true
+-- Number of spaces that a <Tab> in the file counts for
+vim.opt.shiftwidth = 2
+-- Number of spaces that a <Tab> counts for while performing editing operations
+vim.opt.softtabstop = 2
+-- Copy the structure of the existing lines indent when autoindenting a new line
+vim.opt.copyindent = true
+-- When changing the indent of the current line, preserve as much of the indent structure as possible.
+vim.opt.preserveindent = true
+-- how automatic formatting is to be done (useful for Asian text)
+vim.opt.formatoptions:append("mB")
+-- a list of character encodings considered when starting to edit an existing file
+vim.opt.fileencodings = {
+  "ucs-bom",
+  "utf-8",
+  "iso-2022-jp",
+  "euc-jp",
+  "cp932",
+  "default",
+  "latin1",
+}
+
+-- }}}
+-- {{{ UI
+
+-- highlighted column at
+vim.opt.colorcolumn = "81"
+vim.opt.foldenable = false
+-- Markers are used to specify folds
+vim.opt.foldmethod = "marker"
+vim.opt.lazyredraw = true
+-- the use of the mouse is enabled in all modes
+vim.opt.mouse = "a"
+vim.opt.number = true
+-- When a bracket is inserted, briefly jump to the matching one
+vim.opt.showmatch = true
+-- the title of the window will be set to the value of 'titlestring'
+vim.opt.title = true
+-- case is ignored when completing file names and directories
+vim.opt.wildignorecase = true
+vim.opt.diffopt = {
+  "internal",
+  "filler",
+  "closeoff",
+  "algorithm:histogram",
+  "indent-heuristic",
+}
+
+-- highlight trailing spaces
+vim.api.nvim_create_autocmd({ "VimEnter", "WinEnter", "ColorScheme" }, {
+  group = augroup,
+  pattern = "*",
+  callback = function()
+    vim.cmd([[highlight TrailingSpaces term=underline guibg=Red ctermbg=Red]])
+    vim.cmd([[match TrailingSpaces /\s\+$/]])
+  end,
+})
+
+-- }}}
+-- {{{ Keybindings
+
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- go to next modified buffer
+vim.keymap.set("n", "<Leader>b", "<Cmd>bmodified<CR>")
+-- find merge conflict marker
+vim.keymap.set({"n", "x", "o"}, "<Leader>fc", [[/\v^[<=>]{7}( .*<Bar>$)<CR>]])
+
+-- text objects
+--- select the entire current line in Visual mode
+vim.keymap.set("x", "al", "<Esc>0v$")
+--- select the inner part of the current line in Visual mode
+vim.keymap.set("x", "il", "<Esc>^vg_")
+--- select the inner part of the current line in Operator-pending mode
+vim.keymap.set("o", "il", "<Cmd>normal! ^vg_<CR>")
+--- select the entire file in visual mode
+vim.keymap.set("x", "ag", "gg0oG$")
+--- select the entire file while preserving the cursor in Operator-pending mode
+vim.keymap.set("o", "ag", [[<Cmd>exe "normal! m`"<Bar>keepjumps normal! ggVG<CR>]])
+
+-- toggles
+--- spell checking
+vim.keymap.set("n", "<Leader>ts", "<Cmd>setlocal spell! spell?<CR>")
+-- show the line number relative to the current line
+vim.keymap.set("n", "<Leader>t#", "<Cmd>setlocal relativenumber! relativenumber?<CR>")
+
+-- }}}
+
+vim.keymap.set('n', '<C-q>', '<Nop>')
+vim.keymap.set('v', '<C-q>', '<Nop>')


### PR DESCRIPTION
nvim用の設定ファイル`init.lua`を追加

- `vim.opt.backup`
https://vim-jp.org/vimdoc-en/options.html#'backup'
- `vim.opt.backupdir:remove(".")`
https://vim-jp.org/vimdoc-en/options.html#'backupdir'
  - current directoryにバックアップを保存しない
  - `remove`
https://vim-jp.org/vimdoc-en/if_lua.html#lua-list
- `vim.opt.undofile = true`
https://vim-jp.org/vimdoc-en/options.html#'undofile'
- `vim.opt.ignorecase = true`
https://vim-jp.org/vimdoc-en/options.html#'ignorecase'
- `vim.opt.smartcase = true`
https://vim-jp.org/vimdoc-en/options.html#'smartcase'
- `vim.opt.expandtab = true`
https://vim-jp.org/vimdoc-en/options.html#'expandtab'
- `vim.opt.shiftwidth`
https://vim-jp.org/vimdoc-en/options.html#'shiftwidth'
- `vim.opt.softtabstop`
https://vim-jp.org/vimdoc-en/options.html#'softtabstop'
- `vim.opt.copyindent`
https://vim-jp.org/vimdoc-en/options.html#'copyindent'
- `vim.opt.preserveindent`
https://vim-jp.org/vimdoc-en/options.html#'preserveindent'
- `vim.opt.formatoptions:append("mB")`
https://vim-jp.org/vimdoc-en/options.html#'formatoptions'
- `vim.opt.fileencodings`
https://vim-jp.org/vimdoc-en/options.html#'fileencodings'
- `vim.opt.colorcolumn `
https://vim-jp.org/vimdoc-en/options.html#'colorcolumn'
- `vim.opt.foldenable`
https://vim-jp.org/vimdoc-en/options.html#'foldenable'
- `vim.opt.foldmethod`
https://vim-jp.org/vimdoc-en/options.html#'foldmethod'
- `vim.opt.lazyredraw`
https://vim-jp.org/vimdoc-en/options.html#'lazyredraw'
- `vim.opt.mouse`
https://vim-jp.org/vimdoc-en/options.html#'mouse'
- `vim.opt.number`
https://vim-jp.org/vimdoc-en/options.html#'number'
- `vim.opt.showmatch`
https://vim-jp.org/vimdoc-en/options.html#'showmatch'
- `vim.opt.title`
https://vim-jp.org/vimdoc-en/options.html#'title'
- `vim.opt.wildignorecase`
https://vim-jp.org/vimdoc-en/options.html#'wildignorecase'
- `vim.opt.diffopt`
https://vim-jp.org/vimdoc-en/options.html#'diffopt'
- highlight trailing spaces
cf. https://github.com/youn410/dotfiles/pull/19
  - `nvim_create_autocmd`
https://neovim.io/doc/user/api.html#nvim_create_autocmd()
- `vim.g.mapleader`
https://vim-jp.org/vimdoc-en/map.html#mapleader
- `vim.g. maplocalleader`
https://vim-jp.org/vimdoc-en/map.html#maplocalleader
- `vim.keymap.set("n", "<Leader>b", "<Cmd>bmodified<CR>")`
go to next modified buffer
https://vim-jp.org/vimdoc-en/windows.html#:bmodified
  - demo
![output](https://github.com/user-attachments/assets/283bf759-d6e9-481a-a098-178f4b34a86d)
  - バッファのあるファイルを` b`で切り替えて表示している
- `vim.keymap.set({"n", "x", "o"}, "<Leader>fc", [[/\v^[<=>]{7}( .*<Bar>$)<CR>]])`
find merge conflict marker
![output](https://github.com/user-attachments/assets/274172e9-ad4e-4056-9127-20e14a29dd61)
  - `vim.keymap.set`
https://neovim.io/doc/user/lua.html#vim.keymap.set()
    - 第一引数: 対象となるモード
    - 第二引数: キーの組み合わせ（ショートカット）
    - 第三引数: 実行するコマンド
  - `{ "n", "x", "o" }`
    - このキーマッピングが有効なモード
      - "n": ノーマルモード
      - "x": ビジュアルモード
      - "o": オペレータ待機モード
VimやNeovimで特定の「オペレータコマンド」（例: d、y、c など）を実行した後、どの範囲に対して操作を行うかを指定するモード
  - `[[/\v^[<=>]{7}( .*<Bar>$)<CR>]]`
    - `[[]]`: 文字列リテラル
https://www.lua.org/pil/2.4.html
    - `/`: 検索開始
    - `\v`: エクストラ検索モード（very magic）を有効化
      - このモードでは、特殊文字（例: *, +, ()）をエスケープなしで使用可能
https://vim-jp.org/vimdoc-en/pattern.html#/\v
    - `^[<=>]{7}( .*<Bar>$)<CR>`
      - `^`: 行の先頭
      - `[<=>]{7}`: <, =, または > が7回連続するパターン
        - 例: `<<<<<<<`, `=======`, `>>>>>>>`
    - ` .*<Bar>$`
      - 前者は`<<<<<<< develp`とか`>>>>>>> develop`にマッチ
      - 後者は`=======`だけにマッチ
    - `<Bar>`: `|`のこと。or条件
https://vim-jp.org/vimdoc-en/map.html#map_bar
      - `<CR>`: エンターキーをシミュレートして検索を確定
https://vim-jp.org/vimdoc-en/intro.html#carriage-return
- `vim.keymap.set("x", "al", "<Esc>0v$")`
select the entire current line in Visual mode
![output](https://github.com/user-attachments/assets/70d9919c-8f7d-419e-b061-4e15de3f2ddf)
  - `<Esc>`: Visualモードから一時的にNormalモード に戻る
  - `0`: 現在の行の先頭へ移動
  - `v`: 再びVisualモードへ移行
  - `$`
    - 現在の行の末尾に移動
    - Visualモードなので、先頭から末尾まで選択される
- `vim.keymap.set("x", "il", "<Esc>^vg_")`
select the inner part of the current line in Visual mode
![output](https://github.com/user-attachments/assets/e6ee7668-9353-4bb2-b64e-42e63f6ee556)
  - `<Esc>`: Visualモードから一時的にNormalモードに戻る
  - `^`: 現在の行の最初の非空白文字
  - `v`: Visualモード開始
  - `g_`
[https://vim-jp.org/vimdoc-en/motion.html#g_](https://vim-jp.org/vimdoc-en/motion.html#g_)
    - 現在の行の最後の非空白文字
    - 現在の行の「最初の非空白文字」から「最後の非空白文字」までがビジュアルモードで選択される
- `vim.keymap.set("o", "il", "<Cmd>normal! ^vg_<CR>")`
select the inner part of the current line in Operator-pending mode
![output](https://github.com/user-attachments/assets/c5d72678-7cc1-4745-acd8-4ff9bdf03c20)
  - `<Cmd>`
https://vim-jp.org/vimdoc-en/map.html#%3CCmd%3E
    - modeを変化せずにコマンドを実行
  - `normal!`
https://vim-jp.org/vimdoc-en/various.html#:normal
    - normalモードのコマンドを実行する
    - `!`があるのでユーザ定義のmappingの影響を受けない
      - 例
        - `nnoremap ^ 0`は「^の挙動」（行の最初の非空白文字に移動する）を`0`（行頭に移動）に置き換えている
        - `normal ^`を実行すると、「行頭に移動する」（置き換えた挙動）
        - `normal! ^`を実行すると「行の最初の非空白文字に移動する」（置き換える前の挙動）
  - `^`: 現在の行の最初の非空白文字に移動
  - `v`: Visualモードに移行（選択を開始）
https://vim-jp.org/vimdoc-en/visual.html#v
  - `g_`: 現在の行の最後の非空白文字に移動（選択を拡張）。
https://vim-jp.org/vimdoc-en/motion.html#g
  - `<CR>`: コマンドを実行して確定
https://vim-jp.org/vimdoc-en/intro.html#carriage-return
- `vim.keymap.set("x", "ag", "gg0oG$")`
select the entire file in visual mode
![output](https://github.com/user-attachments/assets/e8b429ae-3b73-4211-87f2-44658a3967c2)
  - `gg`: 1業目の先頭に移動
 https://vim-jp.org/vimdoc-en/motion.html#gg
  - `0`: その行の先頭に移動（実質不要）
  - `G`: 最終行の最初の非空白文字に移動
https://vim-jp.org/vimdoc-en/motion.html#G
  - `$`: その行の末尾に移動
https://vim-jp.org/vimdoc-en/motion.html#$
    - Visualモードでファイル全体を選択し、カーソルが末尾に移動する
- ``vim.keymap.set("o", "ag", [[<Cmd>exe "normal! m`"<Bar>keepjumps normal! ggVG<CR>]])``
![output](https://github.com/user-attachments/assets/fa21b9be-fdb3-4803-86a6-56932631ebba)
select the entire file while preserving the cursor in Operator-pending mode 
  - `<Cmd>`: modeを変化せずにコマンドを実行
https://vim-jp.org/vimdoc-en/map.html#%3CCmd%3E
  - `exe  {comand}`: コマンドを実行
https://vim-jp.org/vimdoc-en/eval.html#:execute
  - ``normal! m```
    - ノーマルモードのコマンドを実行
    - 現在のカーソル位置を保存
https://vim-jp.org/vimdoc-en/motion.html#m'
      - "``"を実行すると保存した位置に戻る 
  - `<Bar>`
https://vim-jp.org/vimdoc-en/intro.html#%3CBar%3E
https://vim-jp.org/vimdoc-en/map.html#map_bar
    - 複数コマンドを連続して実行
  - `keepjumps`: 直後のコマンドで実行したカーソル移動を保存しない
https://vim-jp.org/vimdoc-en/motion.html#:keepjumps
  - `gg`: ファイル先頭に移動
https://vim-jp.org/vimdoc-en/motion.html#gg
  - `V`: 行単位のVisualモード開始
https://vim-jp.org/vimdoc-en/visual.html#V
  - `V`: 最終行へ移動
https://vim-jp.org/vimdoc-en/motion.html#G
  - `<CR>`: コマンドを実行して確定
https://vim-jp.org/vimdoc-en/intro.html#carriage-return
- `vim.keymap.set("n", "<Leader>ts", "<Cmd>setlocal spell! spell?<CR>")`
![output](https://github.com/user-attachments/assets/c6549a13-58e0-454a-b34b-2b6955b25f01)
  - `setlocal`: 現在のバッファのみに有効な設定を実行
https://vim-jp.org/vimdoc-en/options.html#:setlocal
  - `spell`: スペルチェック有効無効の切り替え
https://vim-jp.org/vimdoc-en/options.html#'spell'
  - `spell?`: スペルチェックの状態を確認
- `vim.keymap.set("n", "<Leader>t#", "<Cmd>setlocal relativenumber! relativenumber?<CR>")`
![output](https://github.com/user-attachments/assets/a218a044-327d-44f8-9142-dea270d33e12)
  - `relativenumber`: カーソル位置からの相対行数で表示
https://vim-jp.org/vimdoc-en/options.html#'relativenumber'