### PR TITLE
add: nvim-tree plugin for neovim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Nix configuration for dotfiles";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -34,7 +34,7 @@
 
     homeConfigurations = {
       myHomeConfig = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
+        pkgs = pkgs;
 
         extraSpecialArgs = {
           inherit inputs;

--- a/home/.config/nvim/init.lua
+++ b/home/.config/nvim/init.lua
@@ -1,5 +1,23 @@
 local augroup = vim.api.nvim_create_augroup("vimrc", { clear = true })
 
+-- {{{ Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+-- }}}
+
 -- {{{ General
 
 -- keep backup file after overwriting a file

--- a/home/.config/nvim/init.lua
+++ b/home/.config/nvim/init.lua
@@ -101,6 +101,12 @@ vim.api.nvim_create_autocmd({ "VimEnter", "WinEnter", "ColorScheme" }, {
 vim.g.mapleader = " "
 vim.g.maplocalleader = "\\"
 
+-- Setup lazy.nvim
+require("lazy").setup({
+  spec = { import = "plugins" },
+  checker = { enabled = true },
+})
+
 -- go to next modified buffer
 vim.keymap.set("n", "<Leader>b", "<Cmd>bmodified<CR>")
 -- find merge conflict marker

--- a/home/.config/nvim/lua/plugins/colorscheme.lua
+++ b/home/.config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,8 @@
+return {
+  { "neanias/everforest-nvim" },
+  { "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "everforest",
+    },
+  },
+}

--- a/home/.config/nvim/lua/plugins/devicons.lua
+++ b/home/.config/nvim/lua/plugins/devicons.lua
@@ -1,0 +1,9 @@
+return {
+  "nvim-tree/nvim-web-devicons",
+  lazy = true,
+  config = function()
+    require('nvim-web-devicons').setup({
+      default = true,
+    })
+  end,
+}

--- a/home/.config/nvim/lua/plugins/nvim-tree.lua
+++ b/home/.config/nvim/lua/plugins/nvim-tree.lua
@@ -1,0 +1,41 @@
+local function my_on_attach(bufnr)
+  local api = require "nvim-tree.api"
+
+  local function opts(desc)
+    return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
+  end
+
+  -- default mappings
+  api.config.mappings.default_on_attach(bufnr)
+
+  -- custom mappings
+  vim.keymap.set("n", "v", api.node.open.vertical, opts("Open: Vertical Split"))
+  vim.keymap.set("n", "s", api.node.open.horizontal, opts("Open: Horizontal Split"))
+end
+
+return {
+  "nvim-tree/nvim-tree.lua",
+  version = "*",
+  lazy = false,
+  dependencies = {
+    "nvim-tree/nvim-web-devicons",
+  },
+  config = function()
+    require("nvim-tree").setup({
+      actions = {
+        open_file = {
+          window_picker = {
+            enable = false,
+          },
+        },
+      },
+      filters = {
+        dotfiles = false,
+      },
+      on_attach = my_on_attach,
+      view = {
+        width = 30,
+      },
+    })
+  end,
+}

--- a/home/.config/nvim/lua/plugins/snacks.lua
+++ b/home/.config/nvim/lua/plugins/snacks.lua
@@ -1,0 +1,5 @@
+return {
+  "folke/snacks.nvim",
+  priority = 1000,
+  lazy = false,
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -24,6 +24,7 @@ in {
       fzf
       git
       neovim
+      nerd-fonts.hack
       gnused
       gnugrep
       gawk


### PR DESCRIPTION
nvimのファイラープラグイン`nvim-tree`を導入

- 6b45122812f533dbe42a88935a650617d4417911
  - `nixpkgs.url`を`github:nixos/nixpkgs?ref=nixos-unstable`に置き換え
    - 置き換えないと`nerd-fonts.hack`がインストールできなかった
- 010c2206031a27f5cd79eda718b64df86c9e4ded
  - https://lazy.folke.io/installation の`Single File Setup`を参考にneovim plugin manager `lazy.nvim`を導入
- f70366df67a8aaa8d5ad75de97fb8faff632b235
  - `lazy.nvim`プラグインを`~/.config/nvim/lua/plugins/*.lua`で定義する
    - https://lazy.folke.io/usage/structuring
- c9af1e176bdf285171bebcc98d45b16d69fe4334
  - カラースキーマをプラグインで設定
https://github.com/neanias/everforest-nvim
    - `everforest-nvim`だけだと、ファイルを開く際に下記エラーが発生する
      ```
      Failed loading lazyvim.config.keymaps
      
      ...ocal/share/nvim/lazy/LazyVim/lua/lazyvim/util/format.lua:182: attempt to index global 'Snacks' (a nil value)
      
      # stacktrace:
        - /LazyVim/lua/lazyvim/util/format.lua:182 _in_ **snacks_toggle**
        - /LazyVim/lua/lazyvim/config/keymaps.lua:127
        - /LazyVim/lua/lazyvim/config/init.lua:252
        - /LazyVim/lua/lazyvim/config/init.lua:251 _in_ **_load**
        - /LazyVim/lua/lazyvim/config/init.lua:259 _in_ **load**
        - /LazyVim/lua/lazyvim/config/init.lua:185
      続けるにはENTERを押すかコマンドを入力してください
      ```
    - エラー解消のため、以下のプラグインも導入
https://github.com/folke/snacks.nvim
- 13b81e629efdd40d3e46f7052edb8173aa1f9865
  - `nvim-tree`導入
https://github.com/nvim-tree/nvim-tree.lua
  - ファイルを開くときwindowを分割して開くkeymapを設定
    - `api.node.open.vertical`
      - `:help nvim-tree-api.node.open.vertical`で確認
        ```
        node.open.vertical({node})                nvim-tree-api.node.open.vertical()
            nvim-tree-api.node.edit(), file will be opened in a new vertical split.
        ```
      - `:help nvim-tree-api.node.open.horizontal`
        ```
        node.open.horizontal({node})            nvim-tree-api.node.open.horizontal()
            nvim-tree-api.node.edit(), file will be opened in a new horizontal split.
        ```
    - `actions.open_file.window_picker.enable = false`
      - windowが2つ以上あるときに、ファイルを開く場合、分割元のwindowをcurrent windowにする
      - 毎回選択しない
      - `:help nvim-tree.actions.open_file.window_picker`
        ```
            nvim-tree.actions.open_file.window_picker
            Window picker configuration.
        
                nvim-tree.actions.open_file.window_picker.enable
                Enable the feature. If the feature is not enabled, files will open in
                window from which you last opened the tree.
                  Type: boolean, Default: true
        ```
  - `filters.dotfiles = false`
    - dotfileは表示しない
- 20b8f570d4f9845a1f0570aba5f4eed172be6a7a
  - `nvim-tree`にファイルアイコンを表示するために`nvim-web-devicons`プラグインを追加
https://github.com/nvim-tree/nvim-web-devicons
  - 文字化けを解消するために`nerd-fonts`を追加
  - `iterm`で正常に表示させるためにフォント設定を追加
    - `Use a different font`を追加設定する
![スクリーンショット 2024-12-23 18 46 50](https://github.com/user-attachments/assets/e799c279-188e-4309-bff5-87be2cfbc008)