### PR TITLE
chore: add nvim plugins dir to dotfiles list

### DIFF
--- a/conf/dotfile_list
+++ b/conf/dotfile_list
@@ -1,6 +1,7 @@
 .bashrc
 .config/git/config
 .config/nvim/init.lua
+.config/nvim/lua/plugins
 .local/share/zsh/site-functions
 .nvm
 .tmux.conf


### PR DESCRIPTION
`.config/nvim/lua/plugins`ディレクトリをlink
```
% tree ~/.config/nvim/lua
/Users/***/.config/nvim/lua
├── plugins -> /Users/***/.dotfiles/home/.config/nvim/lua/plugins
```