### PR TITLE
feat: keymap for NvimTreeToggle

### DIFF
--- a/home/.config/nvim/init.lua
+++ b/home/.config/nvim/init.lua
@@ -129,6 +129,8 @@ vim.keymap.set("o", "ag", [[<Cmd>exe "normal! m`"<Bar>keepjumps normal! ggVG<CR>
 vim.keymap.set("n", "<Leader>ts", "<Cmd>setlocal spell! spell?<CR>")
 -- show the line number relative to the current line
 vim.keymap.set("n", "<Leader>t#", "<Cmd>setlocal relativenumber! relativenumber?<CR>")
+-- open or close nvim tree
+vim.keymap.set("n", "<Leader>tt", "<Cmd>NvimTreeToggle<CR>")
 
 -- }}}
 


### PR DESCRIPTION
` tt`でnvim treeの開閉を実施
cf. https://github.com/nvim-tree/nvim-tree.lua/blob/68fc4c20f5803444277022c681785c5edd11916d/doc/nvim-tree-lua.txt#L276-L280
![output](https://github.com/user-attachments/assets/ca0258dd-c4f2-4bdf-946e-39660dd2c3fc)
