### PR TITLE
feat: migrate Node.js version management from nvm to mise

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "home/.nvm"]
-	path = files/.nvm
-	url = https://github.com/nvm-sh/nvm.git

--- a/files/.zshrc
+++ b/files/.zshrc
@@ -111,12 +111,10 @@ unsetopt nomatch # Do not raise error when glob can not be expanded
 # Set up fzf key bindings and fuzzy completion
 source <(fzf --zsh)
 
-###############
-#  loads nvm  #
-###############
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+##########
+#  mise  #
+##########
+(( $+commands[mise] )) && eval "$(mise activate zsh)"
 
 ##########
 #  Path  #

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,10 @@
     home-manager,
     ...
   } @ inputs: let
-    system = "x86_64-darwin";
-    pkgs = import nixpkgs { inherit system; };
+    cfg = import ./nix/config.nix;
+    pkgs = import nixpkgs { system = cfg.system; };
   in {
-    apps.${system}.update = {
+    apps.${cfg.system}.update = {
       type = "app";
       program = toString (pkgs.writeShellScript "update-script" ''
         set -e
@@ -38,6 +38,7 @@
 
         extraSpecialArgs = {
           inherit inputs;
+          dotfilesConfig = cfg;
         };
 
         modules = [ ./nix/home.nix ];

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,0 +1,8 @@
+{
+  user = {
+    name = "nomu";
+    homeDirectory = "/Users/nomu";
+  };
+
+  system = "x86_64-darwin";
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,11 +1,12 @@
 {
   inputs,
+  dotfilesConfig,
   lib,
   config,
   pkgs,
   ...
 }: let
-  username = "nomu";
+  username = dotfilesConfig.user.name;
 in {
   nixpkgs = {
     overlays = [
@@ -15,7 +16,7 @@ in {
 
   home = {
     inherit username;
-    homeDirectory = "/Users/${username}";
+    homeDirectory = dotfilesConfig.user.homeDirectory;
 
     packages = with pkgs; [
       coreutils

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,49 +1,20 @@
 {
-  inputs,
   dotfilesConfig,
-  lib,
-  config,
-  pkgs,
   ...
-}: let
-  username = dotfilesConfig.user.name;
-in {
-  nixpkgs = {
-    overlays = [
-      inputs.neovim-nightly-overlay.overlays.default
-    ];
-  };
+}: {
+  imports = [
+    ./modules/base.nix
+    ./modules/direnv.nix
+    ./modules/git.nix
+    ./modules/neovim.nix
+    ./modules/tmux.nix
+    ./modules/zsh.nix
+  ];
 
   home = {
-    inherit username;
+    username = dotfilesConfig.user.name;
     homeDirectory = dotfilesConfig.user.homeDirectory;
-
-    packages = with pkgs; [
-      coreutils
-      curl
-      delta
-      fzf
-      git
-      neovim
-      nerd-fonts.hack
-      gnused
-      gnugrep
-      gawk
-      tmux
-      tree
-      watch
-      wget
-    ];
-
     stateVersion = "24.05";
-  };
-
-  programs = {
-    # https://github.com/nix-community/nix-direnv
-    direnv = {
-      enable = true;
-      nix-direnv.enable = true;
-    };
   };
 
   # Let Home Manager install and manage itself.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -6,6 +6,7 @@
     ./modules/base.nix
     ./modules/direnv.nix
     ./modules/git.nix
+    ./modules/mise.nix
     ./modules/neovim.nix
     ./modules/tmux.nix
     ./modules/zsh.nix

--- a/nix/modules/README.md
+++ b/nix/modules/README.md
@@ -1,0 +1,30 @@
+# nix/modules/
+
+## 現在の構成について
+
+各ファイルはツールごとにパッケージや設定をまとめたもの。
+厳密には midchildan/dotfiles でいう **profiles/** に近い粒度。
+
+## modules/ と profiles/ の違い
+
+**modules/** = スイッチ付きの設定を定義する場所
+
+```nix
+options.myGit.enable = lib.mkEnableOption "git";
+
+config = lib.mkIf config.myGit.enable {
+  home.packages = [ pkgs.git ];
+};
+```
+
+**profiles/** = どのマシン・用途でそのスイッチをONにするか決める場所
+
+```nix
+imports = [ ../modules/git.nix ];
+myGit.enable = true;
+```
+
+## 今後の方針
+
+マシンが増えて「このマシンには neovim 不要」などの使い分けが出てきたタイミングで、
+modules（スイッチ定義）と profiles（スイッチを束ねる）に分離することを検討する。

--- a/nix/modules/base.nix
+++ b/nix/modules/base.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    coreutils
+    curl
+    gawk
+    gnugrep
+    gnused
+    tree
+    watch
+    wget
+  ];
+}

--- a/nix/modules/direnv.nix
+++ b/nix/modules/direnv.nix
@@ -1,0 +1,7 @@
+{ ... }: {
+  # https://github.com/nix-community/nix-direnv
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
+}

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    delta
+    git
+  ];
+}

--- a/nix/modules/mise.nix
+++ b/nix/modules/mise.nix
@@ -1,0 +1,11 @@
+{ ... }: {
+  programs.mise = {
+    enable = true;
+    enableZshIntegration = false; # .zshrc はシンボリックリンク管理のため手動でフック
+    globalConfig = {
+      tools = {
+        node = "lts";
+      };
+    };
+  };
+}

--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -1,0 +1,10 @@
+{ inputs, pkgs, ... }: {
+  nixpkgs.overlays = [
+    inputs.neovim-nightly-overlay.overlays.default
+  ];
+
+  home.packages = with pkgs; [
+    neovim
+    nerd-fonts.hack
+  ];
+}

--- a/nix/modules/tmux.nix
+++ b/nix/modules/tmux.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    tmux
+  ];
+}

--- a/nix/modules/zsh.nix
+++ b/nix/modules/zsh.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    fzf
+  ];
+}

--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -62,25 +62,6 @@ _unlink_file() {
   popd >/dev/null
 }
 
-install_nvm() {
-  local nvmdir="${FILES_DIR}/.nvm"
-  pushd "$nvmdir" >/dev/null
-
-  git fetch --tags origin
-  git checkout --quiet \
-    `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
-
-  source "$nvmdir/nvm.sh"
-
-  if ! command -v nvm >/dev/null; then
-    error_setup_skip "nvm" "failed to install"
-    popd >/dev/null && return
-  fi
-
-  popd >/dev/null
-  success_setup ".nvm"
-}
-
 install_vim_plug() {
   pushd ~ >/dev/null
   vim -es -u .vim/vimrc -i NONE -c "PlugInstall" -c "qa"

--- a/setup.sh
+++ b/setup.sh
@@ -41,12 +41,8 @@ link_file .config/nvim/lua/plugins
 # tmux config
 link_file .tmux.conf
 
-# nvm
-link_file .nvm
-
 if [[ "${UNINSTALL}" -ne 1 ]]; then
   echo "# Running install scripts..."
-  install_nvm
   install_vim_plug
 fi
 


### PR DESCRIPTION
## Summary

- nvmをgit submoduleとして管理していたが、miseに移行
- `nix/modules/mise.nix` を新規作成し、`programs.mise` で宣言的に管理
  - `globalConfig.tools.node = "lts"` → `~/.config/mise/config.toml` を自動生成
  - `enableZshIntegration = false`: `.zshrc` はシンボリックリンク管理のため手動フック
- `files/.zshrc` の nvm ローダーブロックを mise アクティベートガードに置換（direnv と同パターン）
- `setup.sh` / `scripts/lib/setup.sh` から nvm 関連の記述を削除

## Test plan

- [ ] `git submodule status` → 空であること
- [ ] home-manager apply: `nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig`
- [ ] `which mise` → `~/.nix-profile/bin/mise` 等を指すこと
- [ ] `mise --version` → 動作確認
- [ ] `node --version` → LTS版が返ること
- [ ] `grep nvm ~/.zshrc` → 何も出ないこと
- [ ] `cat ~/.config/mise/config.toml` → `node = "lts"` が書かれていること
- [ ] `direnv --version` → 引き続き動作すること（リグレッション確認）