### PR TITLE
refactor: use flake-parts for multi-system support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,6 +35,26 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -53,7 +73,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "neovim-nightly-overlay",
@@ -121,7 +141,7 @@
     },
     "hercules-ci-effects": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": [
           "neovim-nightly-overlay",
           "nixpkgs"
@@ -164,7 +184,7 @@
     "neovim-nightly-overlay": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks",
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-src": "neovim-src",
@@ -235,6 +255,7 @@
     },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nixpkgs": "nixpkgs_2"

--- a/flake.nix
+++ b/flake.nix
@@ -7,42 +7,48 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
 
     neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    home-manager,
-    ...
-  } @ inputs: let
-    cfg = import ./nix/config.nix;
-    pkgs = import nixpkgs { system = cfg.system; };
-  in {
-    apps.${cfg.system}.update = {
-      type = "app";
-      program = toString (pkgs.writeShellScript "update-script" ''
-        set -e
-        echo "Updating flake..."
-        nix flake update
-        echo "Updating home-manager..."
-        nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
-        echo "Update complete!"
-      '');
-    };
+  outputs = { flake-parts, ... } @ inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
 
-    homeConfigurations = {
-      myHomeConfig = home-manager.lib.homeManagerConfiguration {
-        pkgs = pkgs;
-
-        extraSpecialArgs = {
-          inherit inputs;
-          dotfilesConfig = cfg;
+      perSystem = { pkgs, ... }: {
+        apps.update = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "update-script" ''
+            set -e
+            echo "Updating flake..."
+            nix flake update
+            echo "Updating home-manager..."
+            nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
+            echo "Update complete!"
+          '');
         };
+      };
 
-        modules = [ ./nix/home.nix ];
+      flake = {
+        homeConfigurations = let
+          cfg = import ./nix/config.nix;
+        in {
+          myHomeConfig = inputs.home-manager.lib.homeManagerConfiguration {
+            pkgs = import inputs.nixpkgs { system = cfg.system; };
+            extraSpecialArgs = {
+              inherit inputs;
+              dotfilesConfig = cfg;
+            };
+            modules = [ ./nix/home.nix ];
+          };
+        };
       };
     };
-  };
 }


### PR DESCRIPTION
## Summary

- Add `flake-parts` as a flake input
- Declare `systems = [ "x86_64-darwin" "aarch64-darwin" ]`
- Move `apps.update` into `perSystem` so it works on both Intel and Apple Silicon
- Move `homeConfigurations` into `flake` block (system-independent flake output)

## Motivation

Nixpkgs 26.05 will be the last release to support x86_64-darwin.
This change makes it easy to migrate to aarch64-darwin by just updating `system` in `nix/config.nix`.

## Test plan

- [x] `nix flake show` shows `apps.x86_64-darwin.update` and `apps.aarch64-darwin.update`
- [x] `nix run .#update` still works