### PR TITLE
refactor: remove hardcoded system, username, and homeDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ pushd ~/.dotfiles
 ### Bootstrap Nix home-manager
 
 ```sh
-nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
+nix run nixpkgs#home-manager -- switch --flake . --impure
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,9 @@
         "aarch64-darwin"
       ];
 
-      perSystem = { pkgs, ... }: {
+      perSystem = { pkgs, ... }: let
+        cfg = import ./nix/config.nix;
+      in {
         apps.update = {
           type = "app";
           program = toString (pkgs.writeShellScript "update-script" ''
@@ -30,18 +32,14 @@
             echo "Updating flake..."
             nix flake update
             echo "Updating home-manager..."
-            nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
+            nix run nixpkgs#home-manager -- switch --flake . --impure
             echo "Update complete!"
           '');
         };
-      };
 
-      flake = {
-        homeConfigurations = let
-          cfg = import ./nix/config.nix;
-        in {
-          myHomeConfig = inputs.home-manager.lib.homeManagerConfiguration {
-            pkgs = import inputs.nixpkgs { system = cfg.system; };
+        legacyPackages.homeConfigurations = {
+          ${cfg.user.name} = inputs.home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
             extraSpecialArgs = {
               inherit inputs;
               dotfilesConfig = cfg;
@@ -50,5 +48,7 @@
           };
         };
       };
+
+      flake = {};
     };
 }

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,8 +1,9 @@
-{
+let
+  username = builtins.getEnv "USER";
+  homeDir = builtins.getEnv "HOME";
+in {
   user = {
-    name = "nomu";
-    homeDirectory = "/Users/nomu";
+    name = username;
+    homeDirectory = homeDir;
   };
-
-  system = "x86_64-darwin";
 }


### PR DESCRIPTION
## Summary

- `perSystem.legacyPackages.homeConfigurations` に移動し、flake-parts が architecture-aware な `pkgs` を自動提供するようにした（`system = "x86_64-darwin"` のハードコードを廃止）
- `builtins.getEnv "USER"` / `builtins.getEnv "HOME"` で username と homeDirectory を実行時に解決（`--impure` フラグが必要）
- これにより複数マシンへの導入時に `nix/config.nix` を手動編集する必要がなくなる

## Test plan

- [ ] `nix run nixpkgs#home-manager -- switch --flake . --impure` が通ること
- [ ] `which mise`, `direnv --version` など既存ツールが引き続き動作すること
- [ ] 別アーキテクチャ（aarch64-darwin）でも評価エラーが出ないこと