### PR TITLE
feat: protect .zshrc via Nix and add .zshrc.local support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,23 @@ pushd ~/.dotfiles
 ```sh
 nix run nixpkgs#home-manager -- switch --flake . --impure
 ```
+
+## Machine-local zsh configuration
+
+`~/.zshrc` is managed by Nix (home-manager) and is read-only.
+For settings that should not be committed — machine-specific `PATH`, secrets, work aliases, proxy settings, etc. — create `~/.zshrc.local`:
+
+```sh
+touch ~/.zshrc.local
+```
+
+It is sourced automatically at the end of `~/.zshrc`:
+
+```zsh
+# ~/.zshrc.local (not tracked by git)
+export SOME_SECRET=...
+export PATH="$HOME/work/bin:$PATH"
+alias work='cd ~/work'
+```
+
+`~/.zshrc.local` is intentionally excluded from this repository.

--- a/files/.zshrc
+++ b/files/.zshrc
@@ -120,3 +120,9 @@ source <(fzf --zsh)
 #  Path  #
 ##########
 PATH="$HOME/.local/bin:$PATH"
+
+
+###########
+#  Local  #
+###########
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local

--- a/nix/modules/zsh.nix
+++ b/nix/modules/zsh.nix
@@ -2,4 +2,10 @@
   home.packages = with pkgs; [
     fzf
   ];
+
+  programs.zsh = {
+    enable = true;
+    enableCompletion = false;
+    initExtra = builtins.readFile ../../files/.zshrc;
+  };
 }

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,6 @@ fi
 # shell config
 link_file .bashrc
 link_file .zshenv
-link_file .zshrc
 link_file .zlogout
 link_file .local/share/zsh/site-functions
 


### PR DESCRIPTION
## Summary

- Switch `zsh.nix` from `home.file.".zshrc".source` (symlink to repo) to `programs.zsh` so home-manager generates `~/.zshrc` as a read-only Nix store symlink — protected from accidental edits
- Remove `link_file .zshrc` from `setup.sh` to eliminate the conflict with Nix management
- Add `.zshrc.local` loading to `files/.zshrc` for machine-local overrides not tracked in git

## Test plan

- [x] Run `home-manager switch --flake ~/.dotfiles --impure` and confirm `~/.zshrc` is a symlink into `/nix/store/`
- [x] Confirm `~/.zshrc.local` is sourced if it exists
- [x] Confirm existing zsh functionality (completions, key bindings, fzf, mise, direnv) still works