### PR TITLE
fix: rename initExtra to initContent and manage .zshenv via Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,23 @@ pushd ~/.dotfiles
 ```sh
 nix run nixpkgs#home-manager -- switch --flake . --impure
 ```
+
+## Machine-local zsh configuration
+
+`~/.zshrc` is managed by Nix (home-manager) and is read-only.
+For settings that should not be committed — machine-specific `PATH`, secrets, work aliases, proxy settings, etc. — create `~/.zshrc.local`:
+
+```sh
+touch ~/.zshrc.local
+```
+
+It is sourced automatically at the end of `~/.zshrc`:
+
+```zsh
+# ~/.zshrc.local (not tracked by git)
+export SOME_SECRET=...
+export PATH="$HOME/work/bin:$PATH"
+alias work='cd ~/work'
+```
+
+`~/.zshrc.local` is intentionally excluded from this repository.

--- a/files/.zshrc
+++ b/files/.zshrc
@@ -120,3 +120,9 @@ source <(fzf --zsh)
 #  Path  #
 ##########
 PATH="$HOME/.local/bin:$PATH"
+
+
+###########
+#  Local  #
+###########
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local

--- a/files/.zshrc
+++ b/files/.zshrc
@@ -121,7 +121,6 @@ source <(fzf --zsh)
 ##########
 PATH="$HOME/.local/bin:$PATH"
 
-
 ###########
 #  Local  #
 ###########

--- a/nix/modules/zsh.nix
+++ b/nix/modules/zsh.nix
@@ -6,6 +6,7 @@
   programs.zsh = {
     enable = true;
     enableCompletion = false;
-    initExtra = builtins.readFile ../../files/.zshrc;
+    envExtra = builtins.readFile ../../files/.zshenv;
+    initContent = builtins.readFile ../../files/.zshrc;
   };
 }

--- a/nix/modules/zsh.nix
+++ b/nix/modules/zsh.nix
@@ -2,4 +2,10 @@
   home.packages = with pkgs; [
     fzf
   ];
+
+  programs.zsh = {
+    enable = true;
+    enableCompletion = false;
+    initExtra = builtins.readFile ../../files/.zshrc;
+  };
 }

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,6 @@ fi
 # shell config
 link_file .bashrc
 link_file .zshenv
-link_file .zshrc
 link_file .zlogout
 link_file .local/share/zsh/site-functions
 

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,6 @@ fi
 
 # shell config
 link_file .bashrc
-link_file .zshenv
 link_file .zlogout
 link_file .local/share/zsh/site-functions
 


### PR DESCRIPTION
## Summary

Follow-up to #47 — fixes two issues found during `home-manager switch`:

- Rename `programs.zsh.initExtra` → `initContent` (deprecated in latest home-manager)
- Move `.zshenv` ownership to Nix: add `programs.zsh.envExtra` to embed `files/.zshenv` content, and remove `link_file .zshenv` from `setup.sh` — `programs.zsh.enable` generates `~/.zshenv` so the setup.sh symlink caused a conflict

## Test plan

- [ ] `rm ~/.zshrc ~/.zshenv` then re-run `home-manager switch --flake . --impure`
- [ ] Confirm no deprecation warnings
- [ ] Confirm `~/.zshenv` is a Nix store symlink
- [ ] Confirm PATH / `typeset -U` / `GLOBAL_RCS` settings from `files/.zshenv` are still applied