### PR TITLE
feat(git): add recommended git settings via home-manager

### DIFF
--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -31,6 +31,16 @@
       pull.ff           = "only";
       push.default      = "simple";
       rebase.autosquash = true;
+      rebase.autoStash  = true;
+
+      fetch.prune            = true;
+      push.autoSetupRemote   = true;
+      merge.conflictstyle    = "zdiff3";
+      rerere.enabled         = true;
+      branch.sort            = "-committerdate";
+      log.date               = "iso";
+
+      init.defaultBranch = "main";
     };
   };
 


### PR DESCRIPTION
## 概要

`nix/modules/git.nix` に実用的なGit設定を追加した。

## 変更内容

- `init.defaultBranch = "main"` — `git init` 時のデフォルトブランチを `main` に設定
- `rebase.autoStash = true` — rebase前に自動でstash/unstash
- `fetch.prune = true` — リモートで削除されたブランチをfetch時に自動削除
- `push.autoSetupRemote = true` — 新ブランチのpush時に自動でトラッキング設定
- `merge.conflictstyle = "zdiff3"` — コンフリクトマーカーにベースを含めた3way表示
- `rerere.enabled = true` — 同じコンフリクトの解決を記憶・再適用
- `branch.sort = "-committerdate"` — ブランチを最終コミット日時順にソート
- `log.date = "iso"` — `git log` の日付をISO形式に

## テスト方法

- [ ] `home-manager switch` で適用
- [ ] `git config --global --list` で各設定が反映されていることを確認