### PR TITLE
feat(claude): manage CLAUDE.md via home-manager

### DIFF
--- a/files/.claude/CLAUDE.md
+++ b/files/.claude/CLAUDE.md
@@ -1,0 +1,11 @@
+# Claude Code Settings
+
+## Language
+
+- Respond in English by default
+- Switch to Japanese only when explicity instructed
+- Code, variable names, and commit messages are always in English
+
+## English Proofreading
+
+When the user inputs or records English text, correct grammar, vocabulary, and phrasing to natural, accurate English without changing the meaning.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -10,6 +10,7 @@
     ./modules/neovim.nix
     ./modules/tmux.nix
     ./modules/zsh.nix
+    ./modules/claude.nix
   ];
 
   home = {

--- a/nix/modules/claude.nix
+++ b/nix/modules/claude.nix
@@ -1,0 +1,3 @@
+{ ... }: {
+  home.file.".claude/CLAUDE.md".source = ../../files/.claude/CLAUDE.md;
+}


### PR DESCRIPTION
## 概要
Claude Code のプロジェクト設定ファイル (`~/.claude/CLAUDE.md`) を Nix home-manager で管理するようにした。

## 変更内容
- `nix/modules/claude.nix` を新規追加 — `home.file` で `~/.claude/CLAUDE.md` を `files/.claude/CLAUDE.md` からシンボリックリンクとして配置
- `nix/home.nix` に `./modules/claude.nix` のインポートを追加
- `files/.claude/CLAUDE.md` を新規追加 — Claude Code 向けのプロジェクト設定ファイル

## テスト方法
- [ ] `home-manager switch` を実行して `~/.claude/CLAUDE.md` が正しく配置されることを確認

## その他
`files/.vim/plugged/` (vim-plug でインストールされたプラグイン) は今回コミット対象外。