### PR TITLE
feat(claude): manage skills via home-manager

### DIFF
--- a/files/.claude/skills/git-commit/SKILL.md
+++ b/files/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: git-commit
+description: "Commit code changes with conventional commits split by intent. Use when the user wants to commit, stage, or save changes to git. Trigger phrases: 'commit this', 'commit my chages', 'コミットして', 'この変更をコミット', 'stage and commit'. Produces emoji-prefix conventional commits (feat, fix, refactor, improve, etc.), never commits on main/master. Splits commits by intent even within a single file."
+permissionMode: dontAsk
+---
+
+# Purpose
+Understand the changes and create commits at the appropriate granularity based on intent and scope.
+
+# Pre-flight Check
+1. Run `git status -sb` to confirm the current branch
+2. If the branch is `main` or `master`, **stop immediately** and ask the user to switch branches - do not stage or commit anything
+
+# Reference Materials
+If the user provides reference materials (links, docs, design notes, ticket IDs, etc.), use them to inform the commit intent, granularity, and message. Ask for clarification before proceeding if anything is unclear.
+
+# Command Policy
+- Use only `git status`, `git diff`, `git diff --staged`, and `git log` to assess stage - run all three diff variants to avoid missing pre-staged changes
+- Do not run commands outside of allowed-tools
+- Avoid unnecessary commands that trigger permission prompts
+
+# Commit Flow
+1. Run `git status -sb` to check state and branch (stop if main/master)
+2. Review all changes:
+  - `git diff` - unstaged changes
+  - `git diff --staged` - already-staged changes
+  - `git log --oneline -5` - recent commit style for reference
+3. Classify all changes by **intent** (new feature, bug fix, refactor, behavior improvement, breaking change, deletion)
+4. If multiple intents exist, **split into separate commits** - even within a single file
+5. For each group: `git add` → verify with `git diff --staged` → `git commit`
+6. Run `git status -sb` at the end to confirm no remaining changes
+
+# Prefix Reference
+
+| Prefix | When to use |
+| ------ | ----------- |
+| ⚒️ fix | Non-urgent bug fix |
+| 🔥 hotfix | Urgent bug fix with production impact |
+| ✨ feat | New file or feature |
+| 🔧 improve | Improvement that does'nt break existing behavior |
+| 🔀 change | Breaking change or contract change |
+| 🧹 refactor | Code restructuring with no external behavior change |
+| 🚫 disable | Temporary disable or comment-out |
+| 🗑️ remove | Delete a file or feature |
+| 🚀 upgrade | Library or framework version update |
+| ↩️ revert | Roll back a previous change |
+
+# Commit Message Rules
+
+**Language:** English by default. Use the language the user specifies if given.
+
+**Format (one line as a rule):**
+- `<Prefix>: <concise summary>`
+- Add minimal bullet points only when the change is complex enough to cause misunderstanding
+- Forbidden: vague summaries like `fix: multiple updates`
+
+**Content:** Summarize the purpose or value - not a list of operations. Include a scope when the impact is significant (e.g., `(auth)`, `(cdn)`).
+
+# Prohibited
+- Never run or main/master - always stop
+- Never include a `Co-Authored-By` trailer
+- Never include any text indicating the commit was created by Claude (e.g., `🤖 Generated with Claude Code`)

--- a/files/.claude/skills/git-create-pr/SKILL.md
+++ b/files/.claude/skills/git-create-pr/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: git-create-pr
+description: "Create a pull request from the current branch with a structured description. Use when the user wants to create a PR, open a pull request, or push a branch and make a PR. Trigger phrases: 'create a PR', 'make a pull request', 'PRを作って', 'PRを作成して', 'プルリクを作る', 'open a PR'. Pushes the branch if needed and writes a PR body using the repo's PR template if one exists, otherwise uses the default Summary/Background/Changes/Impact structure. Confirms language (Japanese or English) with the user."
+allowed-tools: Bash(git push:*), Bash(git branch:*), Bash(git rev-parse:*), Bash(gh pr create:*), Glob, Read
+---
+
+# Purpose
+Create a consistent Pull Request from existing commits.
+
+Always do the following:
+- Confirm the current branch
+- Ask for confirmation before pushing to remote
+- Create a PR summarizing the changes
+- PR title in English, PR body in the language confirmed with the user
+- Focus on purpose, background, and impact - not a log of operations
+
+# Command Policy
+- Do not run commands outside of allowed-tools
+- Avoid unnecessary commands that trigger permission prompts
+- Command substitution (`$(...)` and backticks) is allowed, but only with commands inside allowed-tools
+
+# Steps
+
+1. Ask the user whether the PR body should be written in Japanese or English
+
+2. Get the current branch name
+  - `git branch --show-current`
+
+3. If the branch has not been pushed yet, show the push command and ask the user for confirmation before running it:
+  - `git push -u origin <current-branch>`
+
+4. Detect PR template using Glob. Check these paths in order (stop at first match):
+  - `.github/pull_request_template.md`
+  - `.github/PULL_REQUEST_TEMPLATE.md`
+  - `docs/pull_request_template.md`
+  - `PULL_REQUEST_TEMPLATE.md`
+
+  If found: read the file with the Read tool and use it as the body template (see "Using a Repo Template" below).
+  If not found: use the default body template (see "Default Body Template" below).
+
+5. Create the Pull Request
+  - `gh pr create --base <base-branch> --title "<title>" --body "<filled-body>"`
+  - Default base branch is `main` unless the user specifies otherwise.
+
+# Using a Repo Template
+
+When a PR template file is found:
+- Read its full contents with the Read tool
+- Fill in all placeholder sections (e.g. `<Replace me>`, `* description here`, `TICKET-*`) with relevant content derived from the branch's commits and diff
+- Check the appropriate checkboxes (e.g. `- [x] Bug fix`) based on the nature of the change
+- Do not remove any sections from the template - keep the structure intact
+- Translate free-text sections into the language confirmed with the user; leave headings/labels as-is
+
+# Default Body Template
+
+Use this when no repo template is found:
+
+```
+### Summary
+Overview of the changes
+
+### Background
+Why this change is necessary
+
+### Changes
+- Key changes (bullet points)
+
+### Impact
+User impact, comatibility, risks
+
+### Notes (optional)
+Additional context for reviewers
+```
+
+# Confluence Usage (background reference only)
+IF the user provides a Confluence page URL, page ID, or title:
+- Use confluence-mcp to read the content
+- Use it as primary source material for understanding background - do not copy it verbatim
+- Do not include the Confluence link in the PR body
+
+Skip this step if no Confluence link is provided.
+
+# Prohibited
+- Vague titles are not allowed
+- Do not simply copy commit log messages
+- Always include purpose and background
+- Never include a `Co-Authored-By` trailer
+- Never include any text indicating the PR was created by Claude (e.g., `🤖 Generated with Claude Code`)

--- a/nix/modules/claude.nix
+++ b/nix/modules/claude.nix
@@ -1,3 +1,6 @@
 { ... }: {
   home.file.".claude/CLAUDE.md".source = ../../files/.claude/CLAUDE.md;
+
+  home.file.".claude/skills/git-commit/SKILL.md".source = ../../files/.claude/skills/git-commit/SKILL.md;
+  home.file.".claude/skills/git-create-pr/SKILL.md".source = ../../files/.claude/skills/git-create-pr/SKILL.md;
 }


### PR DESCRIPTION
## 概要
Claude Code のスキル定義ファイルを dotfiles で管理し、home-manager 経由でシンボリックリンクを張るように設定した。

## 変更内容
- `files/.claude/skills/git-commit/SKILL.md` を追加（コミット作成スキル）
- `files/.claude/skills/git-create-pr/SKILL.md` を追加（PR 作成スキル）
- `nix/modules/claude.nix` にこれら2ファイルの `home.file` エントリを追加

## テスト方法
- [ ] `home-manager switch` を実行し、`~/.claude/skills/git-commit/SKILL.md` と `~/.claude/skills/git-create-pr/SKILL.md` がシンボリックリンクとして作成されることを確認

## その他
なし